### PR TITLE
Fix: TsProject ECMAScript(*.mts) can not import CS.*

### DIFF
--- a/projects/TsProject/tsconfig.json
+++ b/projects/TsProject/tsconfig.json
@@ -7,6 +7,7 @@
     "include": [
         "./src/*",
         "./src/**/*.ts",
+        "./src/**/*.mts",
         "./types/**.d.ts",
         "../Assets/XOR/Typing/",
         "../Assets/Gen/Typing/",


### PR DESCRIPTION
Fix #19