### PR TITLE
Fix: "openupm.cn" has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,32 @@
 
 **[中文简体] | [[English]](./README_EN.md)**
 
-- **如果你对本项目感兴趣, 请点击`star`支持.**  
-- **如果你有任何想法或疑问, 请提交[[PR]](https://github.com/throw-out/puerts-unity-kit/pulls)和[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues)反馈.**  
-- **请悉知: 当前项目中的`TsComponent`丶`ThreadWorker`模块尚未经广泛验证, 其功能或许存在缺陷, 如果你在使用中遇到任何问题请及时通过[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues)反馈.**
+- **如果你对本项目感兴趣，请点击`star`支持。**  
+- **如果你有任何想法或疑问，请提交[[PR]](https://github.com/throw-out/puerts-unity-kit/pulls) 和[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues) 反馈。**  
+- **请悉知：当前项目中的`TsComponent`丶`ThreadWorker`模块尚未经广泛验证，其功能或许存在缺陷，如果你在使用中遇到任何问题请及时通过[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues) 反馈.**
 
 ## 介绍
-> - 本项目是基于[puerts](https://github.com/Tencent/puerts)开发的Unity模板项目,  默认使用[OpenUPM(cn)](https://openupm.cn/)作为Unity包管理器源;  
-> - 本项目使用typescript脚本开发, 运行时支持`commonjs`和`ESM`模块(匹配规则请查看[MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs));  
-> - 本项目支持webgl构建(`ESM`), 使用webgl构建请务必先翻阅[源仓库](https://github.com/zombieyang/puerts_unity_webgl_demo)中[《如何从原有的PuerTS项目中迁移过来？》](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F)一文;  
-> - 集成常用配置或工具(可选), 如[ScriptPacker](./docs/zhcn/ScriptPacker.md)(`脚本打包`/`压缩`/`加密`/`验签`)丶[source-map-support](https://www.npmjs.com/package/source-map-support)丶[javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator)等;
+> - 本项目是基于[puerts](https://github.com/Tencent/puerts)开发的 Unity 模板项目，默认使用[OpenUPM](https://openupm.com/)作为 Unity 包管理器源;  
+> - 本项目使用 typescript 脚本开发，运行时支持`commonjs`和`ESM`模块 (匹配规则请查看[MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs));  
+> - 本项目支持 webgl 构建 (`ESM`), 使用 webgl 构建请务必先翻阅[源仓库](https://github.com/zombieyang/puerts_unity_webgl_demo)中[《如何从原有的 PuerTS 项目中迁移过来？》](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F)一文;  
+> - 集成常用配置或工具 (可选), 如[ScriptPacker](./docs/zhcn/ScriptPacker.md)(`脚本打包`/`压缩`/`加密`/`验签`) 丶[source-map-support](https://www.npmjs.com/package/source-map-support)丶[javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator)等;
 >
-> 了解更多, 请查看[[文档页面]](./docs/zhcn).
+> 了解更多，请查看[[文档页面]](./docs/zhcn).
 
-> `[2023/02/13]`需注意webgl-support在OpenUMP中的最新版本`1.0.0-rc.1`不支持自动附加后缀名匹配, 需等待后续更新
+> `[2023/02/13]`需注意 webgl-support 在 OpenUMP 中的最新版本`1.0.0-rc.1`不支持自动附加后缀名匹配，需等待后续更新
 
 主要功能:
 - TsBehaviour:
-  > 在ts脚本中使用Unity [MonoBehaviour生命周期](https://docs.unity3d.com/2021.3/Documentation/Manual/ExecutionOrder.html)方法;  
+  > 在 ts 脚本中使用 Unity [MonoBehaviour 生命周期](https://docs.unity3d.com/2021.3/Documentation/Manual/ExecutionOrder.html)方法;  
   > [[查看文档]](./docs/zhcn/TsBehaviour.md)
 
 - TsProperties:
-  > 一个单独的序列化类, 可用于保存数据丶挂载UnityEngine.Object对象等操作;  
+  > 一个单独的序列化类，可用于保存数据丶挂载 UnityEngine.Object 对象等操作;  
   > [[查看文档]](./docs/zhcn/TsProperties.md)
 
 - TsComponent:
-  > 对TsBehaviour和TsProperties的结合实现, 可序列化ts脚本中的成员变量和使用Unity生命周期方法, 并实现对ts对象的生命周期管理;  
-  > 允许UGUI事件绑定到ts脚本上([UGUI事件](./docs/zhcn/TsComponentBindUGUIEvents.md));  
+  > 对 TsBehaviour 和 TsProperties 的结合实现，可序列化 ts 脚本中的成员变量和使用 Unity 生命周期方法，并实现对 ts 对象的生命周期管理;  
+  > 允许 UGUI 事件绑定到 ts 脚本上 ([UGUI 事件](./docs/zhcn/TsComponentBindUGUIEvents.md));  
   > [[查看文档]](./docs/zhcn/TsComponent.md)
 
 - ThreadWorker:
@@ -51,18 +51,18 @@
 ## 开始使用
 1. 下载本模板项目;
 2. 进入目录`projects/TsProject`, 执行`npm install` 或 `yarn`命令安装依赖;
-3. 执行`tsc`命令编译typescript项目;
-4. 完成.
+3. 执行`tsc`命令编译 typescript 项目;
+4. 完成。
 
 ## 附加工具
 - [ConsoleRedirect:](./projects/Assets/Samples/Editor/ConsoleRedirect)
-  > 实现从Unity Console单击/双击超链接直接跳转ts脚本
+  > 实现从 Unity Console 单击/双击超链接直接跳转 ts 脚本
 - [HotReload:](./projects/Assets/Samples/Editor/HotReload)
-  > 纯C#实现的js脚本热更新工具(需要`v8 + inspect`支持), 用于运行时即时修改js逻辑快速调试.
+  > 纯C#实现的js脚本热更新工具(需要`v8 + inspect`支持), 用于运行时即时修改 js 逻辑快速调试.
 - [MiniLinkXml:](./projects/Assets/Samples/Editor/MiniLinkXml)
-  > 分析typescript工程, 获取所有使用的C#类型的(支持额外的自定义类型), 生成最小化`link.xml`配置文件.
+  > 分析 typescript 工程，获取所有使用的C#类型的(支持额外的自定义类型), 生成最小化`link.xml`配置文件.
 - [ECMAScript:](./projects/Assets/Samples/Tools/ECMAScript)
-  > C#命名空间生成工具, 可`快速导入`值和类型(例: `import { GameObject} from 'csharp.UnityEngine'`). 使工程同时兼容commonjs和esm模块从而无需额外修改代码.
+  > C#命名空间生成工具, 可`快速导入`值和类型 (例：`import { GameObject} from 'csharp.UnityEngine'`). 使工程同时兼容 commonjs 和 esm 模块从而无需额外修改代码。
 
 ## 规划
 - 无

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **请悉知: 当前项目中的`TsComponent`丶`ThreadWorker`模块尚未经广泛验证, 其功能或许存在缺陷, 如果你在使用中遇到任何问题请及时通过[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues)反馈.**
 
 ## 介绍
-> - 本项目是基于[puerts](https://github.com/Tencent/puerts)开发的Unity模板项目,  默认使用[OpenUPM(cn)](https://openupm.cn/)作为Unity包管理器源;  
+> - 本项目是基于[puerts](https://github.com/Tencent/puerts)开发的Unity模板项目,  默认使用[OpenUPM](https://openupm.com/)作为Unity包管理器源;  
 > - 本项目使用typescript脚本开发, 运行时支持`commonjs`和`ESM`模块(匹配规则请查看[MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs));  
 > - 本项目支持webgl构建(`ESM`), 使用webgl构建请务必先翻阅[源仓库](https://github.com/zombieyang/puerts_unity_webgl_demo)中[《如何从原有的PuerTS项目中迁移过来？》](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F)一文;  
 > - 集成常用配置或工具(可选), 如[ScriptPacker](./docs/zhcn/ScriptPacker.md)(`脚本打包`/`压缩`/`加密`/`验签`)丶[source-map-support](https://www.npmjs.com/package/source-map-support)丶[javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator)等;

--- a/README.md
+++ b/README.md
@@ -3,32 +3,32 @@
 
 **[中文简体] | [[English]](./README_EN.md)**
 
-- **如果你对本项目感兴趣，请点击`star`支持。**  
-- **如果你有任何想法或疑问，请提交[[PR]](https://github.com/throw-out/puerts-unity-kit/pulls) 和[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues) 反馈。**  
-- **请悉知：当前项目中的`TsComponent`丶`ThreadWorker`模块尚未经广泛验证，其功能或许存在缺陷，如果你在使用中遇到任何问题请及时通过[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues) 反馈.**
+- **如果你对本项目感兴趣, 请点击`star`支持.**  
+- **如果你有任何想法或疑问, 请提交[[PR]](https://github.com/throw-out/puerts-unity-kit/pulls)和[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues)反馈.**  
+- **请悉知: 当前项目中的`TsComponent`丶`ThreadWorker`模块尚未经广泛验证, 其功能或许存在缺陷, 如果你在使用中遇到任何问题请及时通过[[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues)反馈.**
 
 ## 介绍
-> - 本项目是基于[puerts](https://github.com/Tencent/puerts)开发的 Unity 模板项目，默认使用[OpenUPM](https://openupm.com/)作为 Unity 包管理器源;  
-> - 本项目使用 typescript 脚本开发，运行时支持`commonjs`和`ESM`模块 (匹配规则请查看[MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs));  
-> - 本项目支持 webgl 构建 (`ESM`), 使用 webgl 构建请务必先翻阅[源仓库](https://github.com/zombieyang/puerts_unity_webgl_demo)中[《如何从原有的 PuerTS 项目中迁移过来？》](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F)一文;  
-> - 集成常用配置或工具 (可选), 如[ScriptPacker](./docs/zhcn/ScriptPacker.md)(`脚本打包`/`压缩`/`加密`/`验签`) 丶[source-map-support](https://www.npmjs.com/package/source-map-support)丶[javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator)等;
+> - 本项目是基于[puerts](https://github.com/Tencent/puerts)开发的Unity模板项目,  默认使用[OpenUPM(cn)](https://openupm.cn/)作为Unity包管理器源;  
+> - 本项目使用typescript脚本开发, 运行时支持`commonjs`和`ESM`模块(匹配规则请查看[MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs));  
+> - 本项目支持webgl构建(`ESM`), 使用webgl构建请务必先翻阅[源仓库](https://github.com/zombieyang/puerts_unity_webgl_demo)中[《如何从原有的PuerTS项目中迁移过来？》](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F)一文;  
+> - 集成常用配置或工具(可选), 如[ScriptPacker](./docs/zhcn/ScriptPacker.md)(`脚本打包`/`压缩`/`加密`/`验签`)丶[source-map-support](https://www.npmjs.com/package/source-map-support)丶[javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator)等;
 >
-> 了解更多，请查看[[文档页面]](./docs/zhcn).
+> 了解更多, 请查看[[文档页面]](./docs/zhcn).
 
-> `[2023/02/13]`需注意 webgl-support 在 OpenUMP 中的最新版本`1.0.0-rc.1`不支持自动附加后缀名匹配，需等待后续更新
+> `[2023/02/13]`需注意webgl-support在OpenUMP中的最新版本`1.0.0-rc.1`不支持自动附加后缀名匹配, 需等待后续更新
 
 主要功能:
 - TsBehaviour:
-  > 在 ts 脚本中使用 Unity [MonoBehaviour 生命周期](https://docs.unity3d.com/2021.3/Documentation/Manual/ExecutionOrder.html)方法;  
+  > 在ts脚本中使用Unity [MonoBehaviour生命周期](https://docs.unity3d.com/2021.3/Documentation/Manual/ExecutionOrder.html)方法;  
   > [[查看文档]](./docs/zhcn/TsBehaviour.md)
 
 - TsProperties:
-  > 一个单独的序列化类，可用于保存数据丶挂载 UnityEngine.Object 对象等操作;  
+  > 一个单独的序列化类, 可用于保存数据丶挂载UnityEngine.Object对象等操作;  
   > [[查看文档]](./docs/zhcn/TsProperties.md)
 
 - TsComponent:
-  > 对 TsBehaviour 和 TsProperties 的结合实现，可序列化 ts 脚本中的成员变量和使用 Unity 生命周期方法，并实现对 ts 对象的生命周期管理;  
-  > 允许 UGUI 事件绑定到 ts 脚本上 ([UGUI 事件](./docs/zhcn/TsComponentBindUGUIEvents.md));  
+  > 对TsBehaviour和TsProperties的结合实现, 可序列化ts脚本中的成员变量和使用Unity生命周期方法, 并实现对ts对象的生命周期管理;  
+  > 允许UGUI事件绑定到ts脚本上([UGUI事件](./docs/zhcn/TsComponentBindUGUIEvents.md));  
   > [[查看文档]](./docs/zhcn/TsComponent.md)
 
 - ThreadWorker:
@@ -51,18 +51,18 @@
 ## 开始使用
 1. 下载本模板项目;
 2. 进入目录`projects/TsProject`, 执行`npm install` 或 `yarn`命令安装依赖;
-3. 执行`tsc`命令编译 typescript 项目;
-4. 完成。
+3. 执行`tsc`命令编译typescript项目;
+4. 完成.
 
 ## 附加工具
 - [ConsoleRedirect:](./projects/Assets/Samples/Editor/ConsoleRedirect)
-  > 实现从 Unity Console 单击/双击超链接直接跳转 ts 脚本
+  > 实现从Unity Console单击/双击超链接直接跳转ts脚本
 - [HotReload:](./projects/Assets/Samples/Editor/HotReload)
-  > 纯C#实现的js脚本热更新工具(需要`v8 + inspect`支持), 用于运行时即时修改 js 逻辑快速调试.
+  > 纯C#实现的js脚本热更新工具(需要`v8 + inspect`支持), 用于运行时即时修改js逻辑快速调试.
 - [MiniLinkXml:](./projects/Assets/Samples/Editor/MiniLinkXml)
-  > 分析 typescript 工程，获取所有使用的C#类型的(支持额外的自定义类型), 生成最小化`link.xml`配置文件.
+  > 分析typescript工程, 获取所有使用的C#类型的(支持额外的自定义类型), 生成最小化`link.xml`配置文件.
 - [ECMAScript:](./projects/Assets/Samples/Tools/ECMAScript)
-  > C#命名空间生成工具, 可`快速导入`值和类型 (例：`import { GameObject} from 'csharp.UnityEngine'`). 使工程同时兼容 commonjs 和 esm 模块从而无需额外修改代码。
+  > C#命名空间生成工具, 可`快速导入`值和类型(例: `import { GameObject} from 'csharp.UnityEngine'`). 使工程同时兼容commonjs和esm模块从而无需额外修改代码.
 
 ## 规划
 - 无

--- a/README_EN.md
+++ b/README_EN.md
@@ -10,7 +10,7 @@
 - **Note: The `TsComponent` and `ThreadWorker` modules in the current project have not been widely verified, and their functionality may have defects. If you encounter any issues during use, please provide feedback through [[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues).**
 
 ## Introduction
-> - This project is a Unity template project developed based on [puerts](https://github.com/Tencent/puerts), using [OpenUPM](https://openupm.cn/) as the default Unity package manager source.
+> - This project is a Unity template project developed based on [puerts](https://github.com/Tencent/puerts), using [OpenUPM](https://openupm.com/) as the default Unity package manager source.
 > - This project is developed using TypeScript scripts, with runtime support for both `commonjs` and `ESM` modules (check [MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs) for matching rules).
 > - This project supports webgl build (`ESM`). If using webgl build, be sure to first read the article ["How to Migrate from the Original PuerTS Project?"](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F) in the [source repository](https://github.com/zombieyang/puerts_unity_webgl_demo).
 > - Integrates common configurations or tools (optional), such as [ScriptPacker](./docs/en/ScriptPacker.md) (`script packaging`/`compression`/`encryption`/`verification`) and [source-map-support](https://www.npmjs.com/package/source-map-support), [javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator), etc.

--- a/README_EN.md
+++ b/README_EN.md
@@ -10,7 +10,7 @@
 - **Note: The `TsComponent` and `ThreadWorker` modules in the current project have not been widely verified, and their functionality may have defects. If you encounter any issues during use, please provide feedback through [[ISSUES]](https://github.com/throw-out/puerts-unity-kit/issues).**
 
 ## Introduction
-> - This project is a Unity template project developed based on [puerts](https://github.com/Tencent/puerts), using [OpenUPM](https://openupm.com/) as the default Unity package manager source.
+> - This project is a Unity template project developed based on [puerts](https://github.com/Tencent/puerts), using [OpenUPM](https://openupm.cn/) as the default Unity package manager source.
 > - This project is developed using TypeScript scripts, with runtime support for both `commonjs` and `ESM` modules (check [MixerLoader.Mode](./projects/Assets/XOR/Runtime/Src/Loader.cs) for matching rules).
 > - This project supports webgl build (`ESM`). If using webgl build, be sure to first read the article ["How to Migrate from the Original PuerTS Project?"](https://github.com/zombieyang/puerts_unity_webgl_demo/wiki/%E5%A6%82%E4%BD%95%E4%BB%8E%E5%8E%9F%E6%9C%89%E7%9A%84PuerTS%E9%A1%B9%E7%9B%AE%E4%B8%AD%E8%BF%81%E7%A7%BB%E8%BF%87%E6%9D%A5%EF%BC%9F) in the [source repository](https://github.com/zombieyang/puerts_unity_webgl_demo).
 > - Integrates common configurations or tools (optional), such as [ScriptPacker](./docs/en/ScriptPacker.md) (`script packaging`/`compression`/`encryption`/`verification`) and [source-map-support](https://www.npmjs.com/package/source-map-support), [javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator), etc.

--- a/projects/Packages/manifest.json
+++ b/projects/Packages/manifest.json
@@ -47,7 +47,7 @@
   "scopedRegistries": [
     {
       "name": "OpenUPM",
-      "url": "https://package.openupm.cn",
+      "url": "https://package.openupm.com",
       "scopes": [
         "com.tencent.puerts.core",
         "com.tencent.puerts.commonjs",

--- a/projects/Packages/packages-lock.json
+++ b/projects/Packages/packages-lock.json
@@ -5,14 +5,14 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {},
-      "url": "https://package.openupm.cn"
+      "url": "https://package.openupm.com"
     },
     "com.tencent.puerts.core": {
       "version": "2.0.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
-      "url": "https://package.openupm.cn"
+      "url": "https://package.openupm.com"
     },
     "com.tencent.puerts.webgl": {
       "version": "2.0.2",
@@ -21,7 +21,7 @@
       "dependencies": {
         "com.tencent.puerts.core": "2.0.2"
       },
-      "url": "https://package.openupm.cn"
+      "url": "https://package.openupm.com"
     },
     "com.tencent.puerts.webgl.jsbuild": {
       "version": "file:../localUPM/webgl-jsbuild/upm",


### PR DESCRIPTION
Fix #20 
"openupm.cn" has been deprecated, changed to "openupm.com"